### PR TITLE
Fix QUOTED_IDENTIFIER migration error by upgrading Azure/sql-action to v2

### DIFF
--- a/.github/workflows/main_skorpfiles-memorizer-api-test.yml
+++ b/.github/workflows/main_skorpfiles-memorizer-api-test.yml
@@ -68,9 +68,8 @@ jobs:
           package: .
 
       - name: Update Azure Database
-        uses: Azure/sql-action@v1
+        uses: Azure/sql-action@v2
         with:
-          server-name: ${{ secrets.DATABASE_SERVER_NAME_MAIN }}
           connection-string: ${{ secrets.DATABASE_CONNECTION_STRING_MAIN }}
-          sql-file: ${{github.workspace}}/update-database.sql
+          path: ${{github.workspace}}/update-database.sql
 

--- a/.github/workflows/stage_skorpfiles-memorizer-api-test-stage.yml
+++ b/.github/workflows/stage_skorpfiles-memorizer-api-test-stage.yml
@@ -69,10 +69,9 @@ jobs:
           package: .
           
       - name: Update Azure Database
-        uses: Azure/sql-action@v1
+        uses: Azure/sql-action@v2
         with:
-          server-name: ${{ secrets.DATABASE_SERVER_NAME_STAGE }}
           connection-string: ${{ secrets.DATABASE_CONNECTION_STRING_STAGE }}
-          sql-file: ${{github.workspace}}/update-database.sql
+          path: ${{github.workspace}}/update-database.sql
 
 


### PR DESCRIPTION
## Summary

- Upgraded `Azure/sql-action` from `v1` to `v2` in both CI/CD workflows (main and stage)
- Removed the now-redundant `server-name` parameter (v2 reads the server from the connection string)
- Renamed `sql-file` -> `path` per the v2 API

## Root cause

The `IdentityUserToApplicationUserDiscriminator` migration executes a raw `UPDATE [dbo].[AspNetUsers]` statement. `AspNetUsers` has two filtered indexes (`UserNameIndex` and `RoleNameIndex`). SQL Server requires `QUOTED_IDENTIFIER ON` for any DML on tables with filtered indexes.

`Azure/sql-action@v1` uses the legacy `System.Data.SqlClient` driver, which opens connections with `QUOTED_IDENTIFIER OFF` by default, causing the error:

> Msg 1934: UPDATE failed because the following SET options have incorrect settings: 'QUOTED_IDENTIFIER'

`Azure/sql-action@v2` uses `Microsoft.Data.SqlClient`, which defaults `QUOTED_IDENTIFIER ON`, resolving the issue.

## Reviewer notes

The `DATABASE_SERVER_NAME_MAIN` and `DATABASE_SERVER_NAME_STAGE` secrets are no longer consumed by the action. They can be cleaned up separately if desired.

Generated with Claude Code